### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ chef-compliance CHANGELOG
 
 This file is used to list changes made in each version of the chef-compliance cookbook.
 
+0.1.1
+-----
+- [Brian Menges](https://github.com/mengesb) - Add `accept_license` attribute, default to `false`. Must be changed to `true` for explicit licese acceptance
+- [Brian Menges](https://github.com/mengesb) - Remove ruby IO.read from long_description in [metadata.rb](metadata.rb)
+
 0.1.0
 -----
 - [Brian Menges](https://github.com/mengesb) - Initial release of chef-compliance

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Attributes
     <td>Arbitrary config to add to chef-compliance.rb</td>
     <td><tt>{}</tt></td>
   </tr>
+  <tr>
+    <td><tt>['chef-compliance']['accept_license']</tt></td>
+    <td>Boolean</td>
+    <td>Change to true to accept license</td>
+    <td><tt>false</tt></td>
+  </tr>
 </table>
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 default['chef-compliance']['version'] = nil
 default['chef-compliance']['package_source'] = nil
 default['chef-compliance']['channel'] = :stable
+default['chef-complaince']['accept_license'] = false
 
 # The Chef Compliance Server must have an API FQDN set.
 # https://docs.chef.io/install_compliance.html

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,8 +3,8 @@ maintainer 'Brian Menges'
 maintainer_email 'mengesb@users.noreply.github.com'
 license 'Apache 2.0'
 description 'Installs/Configures chef-compliance'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+long_description 'Installs/Configures chef-compliance'
+version '0.1.1'
 
 depends 'chef-ingredient', '>= 0.12.0'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 chef_ingredient 'compliance' do
   channel node['chef-compliance']['channel'].to_sym
   version node['chef-compliance']['version']
+  accept_license node['chef-compliance']['accept_license']
   package_source node['chef-compliance']['package_source']
   action :upgrade
 end


### PR DESCRIPTION
- [Brian Menges](https://github.com/mengesb) - Add `accept_license` attribute, default to `false`. Must be changed to `true` for explicit licese acceptance
- [Brian Menges](https://github.com/mengesb) - Remove ruby IO.read from long_description in [metadata.rb](metadata.rb)
